### PR TITLE
User routes cont

### DIFF
--- a/server/models/User.js
+++ b/server/models/User.js
@@ -8,7 +8,11 @@ const userSchema = new Schema({
 		unique: true,
 		match: [/.+@.+\..+/, "Must match an email address!"],
 	},
-	name: {
+	first_name: {
+		type: String,
+		required: true,
+	},
+	last_name: {
 		type: String,
 		required: true,
 	},
@@ -37,7 +41,7 @@ const userSchema = new Schema({
 			ref: "Event",
 		},
 	],
-	accepted_events: [
+	attending_events: [
 		{
 			type: Schema.Types.ObjectId,
 			ref: "Event",
@@ -67,7 +71,7 @@ const userSchema = new Schema({
 			ref: "Calendar",
 		},
 	],
-	accepted_calendars: [
+	subscribed_calendars: [
 		{
 			type: Schema.Types.ObjectId,
 			ref: "Calendar",

--- a/server/routes/api/User/UserDelete.js
+++ b/server/routes/api/User/UserDelete.js
@@ -21,7 +21,7 @@ router.delete("/:id", async (req, res) => {
 		}
 
 		const deletedUser = await User.findByIdAndDelete(req.params.id);
-		res.status(200).json({ message: `Account for ${deletedUser.name} deleted!` });
+		res.status(200).json({ message: `Account for ${deletedUser.first_name} deleted!` });
 	} catch (err) {
 		res.status(400).json(err);
 	}

--- a/server/routes/api/User/UserPost.js
+++ b/server/routes/api/User/UserPost.js
@@ -6,10 +6,12 @@ const { User } = require("../../../models");
 // /api/user/post/create
 router.post("/create", async (req, res) => {
 	try {
-		const { name, email, password } = req.body;
+		const { first_name, last_name, email, password } = req.body;
 
-		const user = await User.create({ name, email, password });
-		res.status(200).json({ message: `Account for ${name} created!`, user });
+		const user = await User.create({ first_name, last_name, email, password });
+		res
+			.status(200)
+			.json({ message: `Account for ${first_name} ${last_name} created!`, user });
 	} catch (err) {
 		if (err.code === 11000 && err.keyPattern && err.keyValue) {
 			// Duplicate key error for email field

--- a/server/routes/api/User/UserPut.js
+++ b/server/routes/api/User/UserPut.js
@@ -15,17 +15,21 @@ router.put("/:id", async (req, res) => {
 			confirmationNewPassword,
 			existingPassword,
 		} = req.body;
-		let updatedField;
+		let updatedField = {};
 
-		if (newFirstName && newLastName) {
-			updatedField = { first_name: newFirstName, last_name: newLastName };
-		} else if (newFirstName) {
-			updatedField = { first_name: newFirstName };
-		} else if (newLastName) {
-			updatedField = { last_name: newLastName };
-		} else if (newEmail) {
-			updatedField = { email: newEmail };
-		} else if (newPassword) {
+		if (newFirstName) {
+			updatedField.first_name = newFirstName;
+		}
+
+		if (newLastName) {
+			updatedField.last_name = newLastName;
+		}
+
+		if (newEmail) {
+			updatedField.email = newEmail;
+		}
+
+		if (newPassword) {
 			// if resetting password, asks for existing password and new password typed twice
 			if (!existingPassword) {
 				return res.status(400).send("Please enter your existing password.");
@@ -44,9 +48,11 @@ router.put("/:id", async (req, res) => {
 				return res.status(400).send("New passwords don't match.");
 			}
 
-			updatedField = { password: newPassword };
-		} else {
-			res.status(400).send("No field to update.");
+			updatedField.password = newPassword;
+		}
+
+		if (Object.keys(updatedField).length === 0) {
+			return res.status(400).send("No updates provided.");
 		}
 
 		const updatedUser = await User.findByIdAndUpdate(req.params.id, updatedField, {

--- a/server/routes/api/User/UserPut.js
+++ b/server/routes/api/User/UserPut.js
@@ -7,12 +7,22 @@ const { estimatedDocumentCount } = require("../../../models/User");
 // /api/user/put/:id
 router.put("/:id", async (req, res) => {
 	try {
-		const { newName, newEmail, newPassword, confirmationNewPassword, existingPassword } =
-			req.body;
+		const {
+			newFirstName,
+			newLastName,
+			newEmail,
+			newPassword,
+			confirmationNewPassword,
+			existingPassword,
+		} = req.body;
 		let updatedField;
 
-		if (newName) {
-			updatedField = { name: newName };
+		if (newFirstName && newLastName) {
+			updatedField = { first_name: newFirstName, last_name: newLastName };
+		} else if (newFirstName) {
+			updatedField = { first_name: newFirstName };
+		} else if (newLastName) {
+			updatedField = { last_name: newLastName };
 		} else if (newEmail) {
 			updatedField = { email: newEmail };
 		} else if (newPassword) {
@@ -49,7 +59,7 @@ router.put("/:id", async (req, res) => {
 
 		res
 			.status(200)
-			.json({ message: `Account for ${updatedUser.name} updated!`, updatedUser });
+			.json({ message: `Account for ${updatedUser.first_name} updated!`, updatedUser });
 	} catch (err) {
 		return res.status(400).json(err);
 	}
@@ -93,7 +103,7 @@ router.put("/event/attending-status/:id", async (req, res) => {
 		});
 
 		res.status(200).json({
-			message: `Event added to ${updatedUser.name}'s ${attendingStatus} events!`,
+			message: `Event added to ${updatedUser.first_name}'s ${attendingStatus} events!`,
 			updatedUser,
 		});
 	} catch (err) {
@@ -144,7 +154,7 @@ router.put("/event/owned-or-admin/:id", async (req, res) => {
 		});
 
 		res.status(200).json({
-			message: `Event added to ${updatedUser.name}'s ${ownedStatus} events!`,
+			message: `Event added to ${updatedUser.first_name}'s ${ownedStatus} events!`,
 			updatedUser,
 		});
 	} catch (err) {
@@ -223,7 +233,7 @@ router.put("/calendar/subscribed-status/:id", async (req, res) => {
 		});
 
 		res.status(200).json({
-			message: `Calendar added to ${updatedUser.name}'s ${subscribedStatus} calendars!`,
+			message: `Calendar added to ${updatedUser.first_name}'s ${subscribedStatus} calendars!`,
 			updatedUser,
 		});
 	} catch (err) {
@@ -275,7 +285,7 @@ router.put("/calendar/owned-or-admin/:id", async (req, res) => {
 		});
 
 		res.status(200).json({
-			message: `Calendar added to ${updatedUser.name}'s ${ownedStatus} calendars!`,
+			message: `Calendar added to ${updatedUser.first_name}'s ${ownedStatus} calendars!`,
 			updatedUser,
 		});
 	} catch (err) {

--- a/server/routes/api/User/UserPut.js
+++ b/server/routes/api/User/UserPut.js
@@ -1,5 +1,6 @@
 const router = require("express").Router();
 const { User } = require("../../../models");
+const { estimatedDocumentCount } = require("../../../models/User");
 
 // Update User name, email, or password, usable route for all three separate update functions.
 // Would require the update requests to be sent indivdually, not designed for multiple updates at once.
@@ -38,13 +39,225 @@ router.put("/:id", async (req, res) => {
 			res.status(400).send("No field to update.");
 		}
 
-		const user = await User.findByIdAndUpdate(req.params.id, updatedField, { new: true });
+		const updatedUser = await User.findByIdAndUpdate(req.params.id, updatedField, {
+			new: true,
+		});
 
-		if (!user) {
+		if (!updatedUser) {
 			return res.status(404).send("User not found.");
 		}
 
-		res.status(200).json({ message: `Account for ${user.name} updated!`, user });
+		res
+			.status(200)
+			.json({ message: `Account for ${updatedUser.name} updated!`, updatedUser });
+	} catch (err) {
+		return res.status(400).json(err);
+	}
+});
+
+// User portion that adds eventID to appropriate array and handles for checking if an event being added to attending, invited, or declined is already in another array and removes it from that array
+// /api/user/put/event/attending-status/:id
+router.put("/event/attending-status/:id", async (req, res) => {
+	try {
+		const { eventId, attendingStatus } = req.body;
+
+		if (!eventId) {
+			return res.status(400).send("No event ID provided.");
+		}
+
+		// types of attendingStatus are "attending", "invited", "declined"
+		const eventTypes = {
+			attending: "attending_events",
+			invited: "invited_events",
+			declined: "declined_events",
+		};
+
+		if (!eventTypes[attendingStatus]) {
+			return res.status(400).send("Invalid event status.");
+		}
+
+		// Remove the event from other arrays if it exists
+		const updateQuery = {
+			$pull: {},
+			$addToSet: { [eventTypes[attendingStatus]]: eventId },
+		};
+
+		for (const eventType in eventTypes) {
+			if (eventType !== attendingStatus) {
+				updateQuery.$pull[eventTypes[eventType]] = eventId;
+			}
+		}
+
+		const updatedUser = await User.findByIdAndUpdate(req.params.id, updateQuery, {
+			new: true,
+		});
+
+		res.status(200).json({
+			message: `Event added to ${updatedUser.name}'s ${attendingStatus} events!`,
+			updatedUser,
+		});
+	} catch (err) {
+		res.status(400).json(err);
+	}
+});
+
+// User route for creating an event or becoming admin of an event
+// Both admin and owned would be allowed to edit event details, but owned is the original owner
+// /api/user/put/event/owned-or-admin/:id
+router.put("/event/owned-or-admin/:id", async (req, res) => {
+	try {
+		const { eventId, ownedStatus } = req.body;
+
+		if (!eventId) {
+			return res.status(400).send("No event ID provided.");
+		}
+
+		const eventTypes = {
+			owned: "owned_events",
+			admin: "admin_events",
+		};
+
+		if (!eventTypes[ownedStatus]) {
+			return res.status(400).send("Invalid event status.");
+		}
+
+		// if the ownedStatus is owned, also add the event to the attending_events array
+		const updateQuery = {
+			$addToSet: { [eventTypes[ownedStatus]]: eventId },
+		};
+
+		if (ownedStatus === "owned") {
+			updateQuery.$addToSet["attending_events"] = eventId;
+		}
+
+		const updatedUser = await User.findByIdAndUpdate(req.params.id, updateQuery, {
+			new: true,
+		});
+
+		res.status(200).json({
+			message: `Event added to ${updatedUser.name}'s ${ownedStatus} events!`,
+			updatedUser,
+		});
+	} catch (err) {
+		res.status(400).json(err);
+	}
+});
+
+// User portion that adds calendarID to appropriate invited or subscribed array
+// /api/user/put/calendar/subscribed-status/:id
+router.put("/calendar/subscribed-status/:id", async (req, res) => {
+	try {
+		const { calendarId, subscribedStatus } = req.body;
+
+		if (!calendarId) {
+			return res.status(400).send("No calendar ID provided.");
+		}
+
+		// types of subscribedStatus are "subscribed", "invited" (don't track declined)
+		const subscribedTypes = {
+			subscribed: "subscribed_calendars",
+			invited: "invited_calendars",
+			unsubscribed: "unsubscribed_calendars",
+		};
+
+		if (!subscribedTypes[subscribedStatus]) {
+			return res.status(400).send("Invalid event status.");
+		}
+
+		// Check if calendarId exists in either subscribed_calendars or invited_calendars arrays
+		const user = await User.findById(req.params.id);
+		const { subscribed_calendars, invited_calendars, owned_calendars } = user;
+
+		if (
+			subscribed_calendars.includes(calendarId) &&
+			subscribedStatus !== "unsubscribed"
+		) {
+			return res.status(200).send("Already subscribed to calendar!");
+		} else if (invited_calendars.includes(calendarId) && subscribedStatus === "invited") {
+			return res.status(200).send("Already invited to calendar!");
+		} else if (owned_calendars.includes(calendarId)) {
+			return res.status(200).send("Cannot change subscription to owned calendar!");
+		} else if (subscribedStatus === "unsubscribed") {
+			// Remove the calendar from other arrays if it exists
+			const updatedUser = await User.findByIdAndUpdate(
+				req.params.id,
+				{
+					// pull from all arrays
+					$pull: {
+						subscribed_calendars: calendarId,
+						invited_calendars: calendarId,
+						admin_calendars: calendarId,
+					},
+				},
+				{
+					new: true,
+				}
+			);
+
+			return res
+				.status(200)
+				.json({ message: "Calendar unsubscribed/removed!", updatedUser });
+		}
+
+		const updateQuery = {
+			$pull: {},
+			$addToSet: { [subscribedTypes[subscribedStatus]]: calendarId },
+		};
+
+		if (subscribedStatus === "subscribed") {
+			updateQuery.$pull["invited_calendars"] = calendarId;
+		}
+
+		// if the subscribedStatus is unsubscribed, also remove the calendar from all arrays and don't push the id anywhere
+		const updatedUser = await User.findByIdAndUpdate(req.params.id, updateQuery, {
+			new: true,
+		});
+
+		res.status(200).json({
+			message: `Calendar added to ${updatedUser.name}'s ${subscribedStatus} calendars!`,
+			updatedUser,
+		});
+	} catch (err) {
+		res.status(400).json(err);
+	}
+});
+
+// User route for creating a calendar or becoming admin of a calendar
+// Both admin and owned would be allowed to edit calendar details, but owned is the original owner
+// /api/user/put/calendar/owned-or-admin/:id
+router.put("/calendar/owned-or-admin/:id", async (req, res) => {
+	try {
+		const { calendarId, ownedStatus } = req.body;
+
+		if (!calendarId) {
+			return res.status(400).send("No event ID provided.");
+		}
+
+		const calendarTypes = {
+			owned: "owned_calendars",
+			admin: "admin_calendars",
+		};
+
+		if (!calendarTypes[ownedStatus]) {
+			return res.status(400).send("Invalid calendar status.");
+		}
+
+		// if owned or admin, also add the calendar to the subscribed_calendars array
+		const updateQuery = {
+			$addToSet: {
+				[calendarTypes[ownedStatus]]: calendarId,
+				subscribed_calendars: calendarId,
+			},
+		};
+
+		const updatedUser = await User.findByIdAndUpdate(req.params.id, updateQuery, {
+			new: true,
+		});
+
+		res.status(200).json({
+			message: `Calendar added to ${updatedUser.name}'s ${ownedStatus} calendars!`,
+			updatedUser,
+		});
 	} catch (err) {
 		res.status(400).json(err);
 	}

--- a/server/routes/api/User/UserPut.js
+++ b/server/routes/api/User/UserPut.js
@@ -283,13 +283,12 @@ router.put("/calendar/owned-or-admin/:id", async (req, res) => {
 	}
 });
 
-// User route for if event is deleted
-// /api/user/put/event/deleted/:id
-router.put("/event/deleted/:id", async (req, res) => {
+// User route for if event is deleted, removing ID from all users' arrays.
+// /api/user/put/event/deleted/
+router.put("/event/deleted/", async (req, res) => {
 	try {
 		const { eventId } = req.body;
-		const updatedUser = await User.findByIdAndUpdate(
-			req.params.id,
+		const updatedUsers = await User.updateMany(
 			{
 				$pull: {
 					owned_events: eventId,
@@ -304,19 +303,19 @@ router.put("/event/deleted/:id", async (req, res) => {
 
 		res
 			.status(200)
-			.json({ message: `Event removed from ${updatedUser.name}'s events!`, updatedUser });
+			.json({ message: `Event removed from all users' events!`, updatedUsers });
 	} catch (err) {
 		res.status(400).json(err);
 	}
 });
 
-// User route for if calendar is deleted
-// /api/user/put/calendar/deleted/:id
-router.put("/calendar/deleted/:id", async (req, res) => {
+// User route for if calendar is deleted, removing ID from all users' arrays.
+// /api/user/put/calendar/deleted/
+router.put("/calendar/deleted/", async (req, res) => {
 	try {
 		const { calendarId } = req.body;
-		const updatedUser = await User.findByIdAndUpdate(
-			req.params.id,
+		await User.updateMany(
+			{},
 			{
 				$pull: {
 					owned_calendars: calendarId,
@@ -328,9 +327,11 @@ router.put("/calendar/deleted/:id", async (req, res) => {
 			{ new: true }
 		);
 
+		const updatedUsers = await User.find({});
+
 		res.status(200).json({
-			message: `Calendar removed from ${updatedUser.name}'s events!`,
-			updatedUser,
+			message: `Calendar removed from users' calendars!`,
+			updatedUsers,
 		});
 	} catch (err) {
 		res.status(400).json(err);


### PR DESCRIPTION
This continues creating User Routes, this time to handle event and calendar IDs in the user arrays.

Should be handling for all these cases, all tested without JWT. I tried to also predict User Experience necessities (not being able to unsubscribe from a calendar that you own, for example, or adding an event to attending by default if you are adding it to owned(i.e. creating it)). Would love to talk through the logic and thoughts.

Still need to add JWT and that'll probably change how we receive User ID. Also, some of this may need to interact with/be updated to websocket, for live feed refreshing.

Anyway, here are the routes:
Add event id to admin events or owned events (owned adds to attending by default, assuming its the status for creating an event)
Add eventId to invited events, declined events, accepted events (and remove from others if already in)
Add calendars to admin calendars or owned calendars (owned automatically adds to subscribed, assuming its the status for creating a new calendar.
Add Calendars to subscribed or invited, and move between (or remove totally if declined/unsubscribed)
Remove Event ID from all users' arrays if event deleted 
Remove Calendar ID from all users' arrays if calendar deleted 

